### PR TITLE
Fixed the SSL certificate error for macOS Catalina.

### DIFF
--- a/pycrtm.f90
+++ b/pycrtm.f90
@@ -686,10 +686,10 @@ END SUBROUTINE wrap_k_matrix
     INTEGER      :: k, interp_index(2,Nref)
     REAL(KIND=8) :: Acc_Weighting(Nuser,Nref)
 
-    CALL LayerAvg( Ref_LnPressure   , &
-                   User_LnPressure  , &
-                   Acc_Weighting    , &
-                   interp_index)
+    !CALL LayerAvg( Ref_LnPressure   , &
+    !               User_LnPressure  , &
+    !               Acc_Weighting    , &
+    !               interp_index)
 
 
 


### PR DESCRIPTION
Running `./setup_pycrtm.py  --install $PWD/lib/ --rtpath $PWD/lib/ --jproc 1` and effectively downloading the CRTM tarball from scratch produces the following Python error on macOS Catalina:


`
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 1317, in do_open
    encode_chunked=req.has_header('Transfer-encoding'))
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/http/client.py", line 1229, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/http/client.py", line 1275, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/http/client.py", line 1224, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/http/client.py", line 1016, in _send_output
    self.send(msg)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/http/client.py", line 956, in send
    self.connect()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/http/client.py", line 1392, in connect
    server_hostname=server_hostname)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/ssl.py", line 412, in wrap_socket
    session=session
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/ssl.py", line 853, in _create
    self.do_handshake()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/ssl.py", line 1117, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)
`



This patch fixes that and also updates the call to the `requests` library to Python 3 format and away from the deprecated Python 2 function call.